### PR TITLE
Bfd collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Flags:
       --frr.vtysh.timeout="20s"  The timeout when running vtysh commends (default 20s).
       --collector.bgp            Collect BGP Metrics (default: enabled).
       --collector.ospf           Collect OSPF Metrics (default: enabled).
+      --collector.bfd            Collect BFD Metrics (default: enabled).
       --collector.bgp6           Collect BGP IPv6 Metrics (default: disabled).
       --collector.bgpl2vpn       Collect BGP L2VPN Metrics (default: disabled).
       --log.level="info"         Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]
@@ -72,12 +73,13 @@ Name | Description
 --- | ---
 BGP | Per VRF and address family (currently support unicast only) BGP metrics:<br> - RIB entries<br> - RIB memory usage<br> - Configured peer count<br> - Peer memory usage<br> - Configure peer group count<br> - Peer group memory usage<br> - Peer messages in<br> - Peer messages out<br> - Peer received prefixes<br> - Peer advertised prefixes<br> - Peer state (established/down)<br> - Peer uptime
 OSPFv4 | Per VRF OSPF metrics:<br> - Neighbors<br> - Neighbor adjacencies
+BFD | BFD Peer metrics:<br> - Count of total number of peers<br> - BFD Peer State (up/down)<br> - BFD Peer Uptime in seconds
 
 ### Disabled by Default
 Name | Description
 --- | ---
 BGP IPv6 | Per VRF and address family (currently support unicast only) BGP IPv6 metrics:<br> - RIB entries<br> - RIB memory usage<br> - Configured peer count<br> - Peer memory usage<br> - Configure peer group count<br> - Peer group memory usage<br> - Peer messages in<br> - Peer messages out<br> - Peer active prfixes<br> - Peer state (established/down)<br> - Peer uptime
-BGP L2VPN | Per VRF and address family (currently support EVPN only) BGP L2VPN EVPN metrics:<br> - RIB entries<br> - RIB memory usage<br> - Configured peer count<br> - Peer memory usage<br> - Configure peer group count<br> - Peer group memory usage<br> - Peer messages in<br> - Peer messages out<br> - Peer active prfixes<br> - Peer state (established/down)<br> - Peer uptime
+BGP L2VPN | Per VRF and address family (currently support EVPN only) BGP L2VPN EVPN metrics:<br> - RIB entries<br> - RIB memory usage<br> - Configured peer count<br> - Peer memory usage<br> - Configure peer group count<br> - Peer group memory usage<br> - Peer messages in<br> - Peer messages out<br> - Peer active prfixes<br> - Peer state (established/down)<br> - Peer uptime 
 
 ### VTYSH
 The vtysh command is heavily utilised to extract metrics from FRR. The default timeout is 20s but can be modified via the `--frr.vtysh.timeout` flag.

--- a/collector/bfd.go
+++ b/collector/bfd.go
@@ -16,7 +16,7 @@ var (
 	bfdPeerLabels  = []string{"local", "peer"}
 	bfdDesc        = map[string]*prometheus.Desc{
 		"bfdPeerCount":  colPromDesc(bfdSubsystem, "peer_count", "Number of peers detected.", bfdCountLabels),
-		"bfdPeerUptime": colPromDesc(bfdSubsystem, "peer_uptime", "Uptime of bfd peer", bfdPeerLabels),
+		"bfdPeerUptime": colPromDesc(bfdSubsystem, "peer_uptime", "Uptime of bfd peer in seconds", bfdPeerLabels),
 		"bfdPeerState":  colPromDesc(bfdSubsystem, "peer_state", "State of the bfd peer", bfdPeerLabels),
 	}
 	bfdErrors      = []error{}

--- a/collector/bfd.go
+++ b/collector/bfd.go
@@ -1,0 +1,135 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	bfdSubsystem = "bfd"
+
+	bfdCountLabels = []string{}
+	bfdPeerLabels  = []string{"local", "peer"}
+	bfdDesc        = map[string]*prometheus.Desc{
+		"bfdPeerCount":  colPromDesc(bfdSubsystem, "peer_count", "Number of peers detected.", bfdCountLabels),
+		"bfdPeerUptime": colPromDesc(bfdSubsystem, "peer_uptime", "Uptime of bfd peer", bfdPeerLabels),
+		"bfdPeerState":  colPromDesc(bfdSubsystem, "peer_state", "State of the bfd peer", bfdPeerLabels),
+	}
+	bfdErrors      = []error{}
+	totalBFDErrors = 0.0
+)
+
+// BFDCollector collects BFD metrics, implemented as per prometheus.Collector interface.
+type BFDCollector struct{}
+
+// NewBFDCollector returns a BFDCollector struct.
+func NewBFDCollector() *BFDCollector {
+	return &BFDCollector{}
+}
+
+// Name of the collector. Used to populate flag name.
+func (*BFDCollector) Name() string {
+	return bfdSubsystem
+}
+
+// Help describes the metrics this collector scrapes. Used to populate flag help.
+func (*BFDCollector) Help() string {
+	return "Collect BFD Metrics"
+}
+
+// EnabledByDefault describes whether this collector is enabled by default. Used to populate flag default.
+func (*BFDCollector) EnabledByDefault() bool {
+	return true
+}
+
+// Describe implemented as per the prometheus.Collector interface.
+func (*BFDCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, desc := range bfdDesc {
+		ch <- desc
+	}
+}
+
+// Collect implemented as per the prometheus.Collector interface.
+func (c *BFDCollector) Collect(ch chan<- prometheus.Metric) {
+	jsonBFDInterface, err := getBFDInterface()
+	if err != nil {
+		totalBFDErrors++
+		bfdErrors = append(bfdErrors, fmt.Errorf("cannot get bfd peers summary: %s", err))
+	} else {
+		if err = processBFDPeers(ch, jsonBFDInterface); err != nil {
+			totalBFDErrors++
+			bfdErrors = append(bfdErrors, fmt.Errorf("%s", err))
+		}
+	}
+}
+
+// CollectErrors returns what errors have been gathered.
+func (*BFDCollector) CollectErrors() []error {
+	return bfdErrors
+}
+
+// CollectTotalErrors returns total errors.
+func (*BFDCollector) CollectTotalErrors() float64 {
+	return totalBFDErrors
+}
+
+func getBFDInterface() ([]byte, error) {
+	args := []string{"-c", "show bfd peers json"}
+	ctx, cancel := context.WithTimeout(context.Background(), vtyshTimeout)
+	defer cancel()
+
+	output, err := exec.CommandContext(ctx, vtyshPath, args...).Output()
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func processBFDPeers(ch chan<- prometheus.Metric, jsonBFDInterface []byte) error {
+	var bfdPeers []bfdPeer
+	if err := json.Unmarshal(jsonBFDInterface, &bfdPeers); err != nil {
+		return fmt.Errorf("cannot unmarshal bfd peers json: %s", err)
+	}
+
+	// metric is a count of the number of peers
+	newGauge(ch, bfdDesc["bfdPeerCount"], float64(len(bfdPeers)))
+
+	for _, p := range bfdPeers {
+
+		labels := []string{p.Local, p.Peer}
+
+		// get the uptime of the connection to the peer in seconds
+		newGauge(ch, bfdDesc["bfdPeerUptime"], float64(p.Uptime), labels...)
+
+		// state of connection to the bfd peer, up or down
+		var bfdState float64
+		if p.Status == "up" {
+			bfdState = 1
+		}
+		newGauge(ch, bfdDesc["bfdPeerState"], bfdState, labels...)
+	}
+	return nil
+}
+
+type bfdPeer struct {
+	Multihop               bool   `json:"multihop"`
+	Peer                   string `json:"peer"`
+	Local                  string `json:"local"`
+	Vrf                    string `json:"vrf"`
+	ID                     int    `json:"id"`
+	RemoteID               int    `json:"remote-id"`
+	Status                 string `json:"status"`
+	Uptime                 int    `json:"uptime"`
+	Diagnostic             string `json:"diagnostic"`
+	RemoteDiagnostic       string `json:"remote-diagnostic"`
+	ReceiveInterval        int    `json:"receive-interval"`
+	TransmitInterval       int    `json:"transmit-interval"`
+	EchoInterval           int    `json:"echo-interval"`
+	RemoteReceiveInterval  int    `json:"remote-receive-interval"`
+	RemoteTransmitInterval int    `json:"remote-transmit-interval"`
+	RemoteEchoInterval     int    `json:"remote-echo-interval"`
+}

--- a/collector/bfd_test.go
+++ b/collector/bfd_test.go
@@ -1,0 +1,141 @@
+package collector
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+var (
+	bfdPeers = []byte(`[
+		{
+			"multihop": false,
+			"peer": "10.10.141.61",
+			"local": "10.10.141.81",
+			"vrf": "default",
+			"id": 869087474,
+			"remote-id": 533345668,
+			"status": "up",
+			"uptime": 847716,
+			"diagnostic": "ok",
+			"remote-diagnostic": "ok",
+			"receive-interval": 300,
+			"transmit-interval": 300,
+			"echo-interval": 0,
+			"remote-receive-interval": 300,
+			"remote-transmit-interval": 300,
+			"remote-echo-interval": 300
+		},
+		{
+			"multihop": false,
+			"peer": "10.10.141.62",
+			"local": "10.10.141.81",
+			"vrf": "default",
+			"id": 2809641312,
+			"remote-id": 3617154307,
+			"status": "up",
+			"uptime": 847595,
+			"diagnostic": "ok",
+			"remote-diagnostic": "ok",
+			"receive-interval": 300,
+			"transmit-interval": 300,
+			"echo-interval": 0,
+			"remote-receive-interval": 300,
+			"remote-transmit-interval": 300,
+			"remote-echo-interval": 300
+		},
+		{
+			"multihop": false,
+			"peer": "10.10.141.63",
+			"local": "10.10.141.81",
+			"vrf": "default",
+			"id": 2809641312,
+			"remote-id": 3617154307,
+			"status": "down",
+			"uptime": 847888,
+			"diagnostic": "ok",
+			"remote-diagnostic": "ok",
+			"receive-interval": 300,
+			"transmit-interval": 300,
+			"echo-interval": 0,
+			"remote-receive-interval": 300,
+			"remote-transmit-interval": 300,
+			"remote-echo-interval": 300
+		}
+	]
+`)
+	expectedBFDMetrics = map[string]float64{
+		"frr_bfd_peer_count{}": 3,
+		"frr_bfd_peer_uptime{local=10.10.141.81,peer=10.10.141.61}": 847716,
+		"frr_bfd_peer_state{local=10.10.141.81,peer=10.10.141.61}":  1,
+		"frr_bfd_peer_uptime{local=10.10.141.81,peer=10.10.141.62}": 847595,
+		"frr_bfd_peer_state{local=10.10.141.81,peer=10.10.141.62}":  1,
+		"frr_bfd_peer_uptime{local=10.10.141.81,peer=10.10.141.63}": 847888,
+		"frr_bfd_peer_state{local=10.10.141.81,peer=10.10.141.63}":  0,
+	}
+)
+
+func TestProcessBFDPeers(t *testing.T) {
+	ch := make(chan prometheus.Metric, 1024)
+	if err := processBFDPeers(ch, bfdPeers); err != nil {
+		t.Errorf("error calling processBFDPeers ipv4unicast: %s", err)
+	}
+	close(ch)
+
+	// Create a map of following format:
+	//   key: metric_name{labelname:labelvalue,...}
+	//   value: metric value
+	gotMetrics := make(map[string]float64)
+
+	for {
+		msg, more := <-ch
+		if !more {
+			break
+		}
+		metric := &dto.Metric{}
+		if err := msg.Write(metric); err != nil {
+			t.Errorf("error writing metric: %s", err)
+		}
+
+		var labels []string
+		for _, label := range metric.GetLabel() {
+			labels = append(labels, fmt.Sprintf("%s=%s", label.GetName(), label.GetValue()))
+		}
+
+		var value float64
+		if metric.GetCounter() != nil {
+			value = metric.GetCounter().GetValue()
+		} else if metric.GetGauge() != nil {
+			value = metric.GetGauge().GetValue()
+		}
+
+		re, err := regexp.Compile(`.*fqName: "(.*)", help:.*`)
+		if err != nil {
+			t.Errorf("could not compile regex: %s", err)
+		}
+		metricName := re.FindStringSubmatch(msg.Desc().String())[1]
+
+		gotMetrics[fmt.Sprintf("%s{%s}", metricName, strings.Join(labels, ","))] = value
+	}
+
+	for metricName, metricVal := range gotMetrics {
+		if expectedMetricVal, ok := expectedBFDMetrics[metricName]; ok {
+			if expectedMetricVal != metricVal {
+				t.Errorf("metric %s expected value %v got %v", metricName, expectedMetricVal, metricVal)
+			}
+
+		} else {
+			t.Errorf("unexpected metric: %s : %v", metricName, metricVal)
+		}
+	}
+
+	for expectedMetricName, expectedMetricVal := range expectedBFDMetrics {
+		if _, ok := gotMetrics[expectedMetricName]; !ok {
+			t.Errorf("missing metric: %s value %v", expectedMetricName, expectedMetricVal)
+		}
+	}
+}

--- a/collector/ospf.go
+++ b/collector/ospf.go
@@ -15,7 +15,7 @@ var (
 
 	ospfIfaceLabels = []string{"vrf", "iface", "area"}
 	ospfDesc        = map[string]*prometheus.Desc{
-		"ospfIfaceNeigh":    colPromDesc(ospfSubsystem, "neighbors", "Number of neighbors deteceted.", ospfIfaceLabels),
+		"ospfIfaceNeigh":    colPromDesc(ospfSubsystem, "neighbors", "Number of neighbors detected.", ospfIfaceLabels),
 		"ospfIfaceNeighAdj": colPromDesc(ospfSubsystem, "neighbor_adjacencies", "Number of neighbor adjacencies formed.", ospfIfaceLabels),
 	}
 	ospfErrors      = []error{}

--- a/frr_exporter.go
+++ b/frr_exporter.go
@@ -52,6 +52,13 @@ func initCollectors() {
 		Errors:        bgpl2vpn,
 		CLIHelper:     bgpl2vpn,
 	})
+	bfd := collector.NewBFDCollector()
+	collectors = append(collectors, &collector.Collector{
+		Name:          bfd.Name(),
+		PromCollector: bfd,
+		Errors:        bfd,
+		CLIHelper:     bfd,
+	})
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -89,7 +96,9 @@ func parseCLI() {
 		if enabledByDefault == true {
 			defaultState = "enabled"
 		}
-		collector.Enabled = kingpin.Flag(fmt.Sprintf("collector.%s", collector.CLIHelper.Name()), fmt.Sprintf("%s (default: %s).", collector.CLIHelper.Help(), defaultState)).Default(strconv.FormatBool(enabledByDefault)).Bool()
+		flagName := fmt.Sprintf("collector.%s", collector.CLIHelper.Name())
+		helpString := fmt.Sprintf("%s (default: %s).", collector.CLIHelper.Help(), defaultState)
+		collector.Enabled = kingpin.Flag(flagName, helpString).Default(strconv.FormatBool(enabledByDefault)).Bool()
 	}
 	log.AddFlags(kingpin.CommandLine)
 	kingpin.Version(version.Print("frr_exporter"))


### PR DESCRIPTION
Add a FRR BFD collector to the frr exporter. 
Exposes 3  metrics 
- frr_bfd_peer_count{}  - total number of bfd peers connected
- frr_bfd_peer_uptime{local=10.10.141.81,peer=10.10.141.61} - The time in seconds the bfd connection to the peer has been up
- frr_bfd_peer_state{local=10.10.141.81,peer=10.10.141.61} - The up/down state of the bfd peer connection